### PR TITLE
feat: guard sensitive shell exports

### DIFF
--- a/opencode/docs/ai/harness/README.md
+++ b/opencode/docs/ai/harness/README.md
@@ -22,6 +22,9 @@ here.
 - A repeated or fragile rule should become a mechanical check.
 - Harness changes need evidence proportional to risk.
 - Sidecars add observability, not mandatory bureaucracy.
+- Shell hooks are defense in depth: `shell-export-guard` blocks only
+  high-signal secret enumeration and propagation, keeps ordinary setup allowed,
+  and never substitutes for a sandbox.
 
 ## Done Criteria
 

--- a/opencode/docs/ai/harness/checks.md
+++ b/opencode/docs/ai/harness/checks.md
@@ -122,6 +122,12 @@ The harness check validates:
 - `node --test scripts/adversarial-harness.test.mjs` verifies review
   boundaries, paths and symlinks, shell/network permissions, durable approval,
   canaries, supply-chain rules, and corrupt or repeated events;
+- `scripts/shell-export-policy.mjs`, its test suite, and
+  `plugins/shell-export-guard.ts` provide defense in depth at the shell
+  boundary against environment enumeration and high-risk exports. The policy
+  allows ordinary setup such as `PATH` and `NODE_ENV`, never logs commands or
+  values, is not a sandbox, and keeps its rule IDs aligned with the derived Pi
+  extension;
 - presence of `docs/ai/harness/skill_registry.md` (soft check; warns when missing);
 - `agents/lead.md` contains `Skill Resolution` or a registry reference;
 - `developer`, `researcher`, `specifier`, `reviewer`, `designer`, and `scoper`

--- a/opencode/plugins/shell-export-guard.ts
+++ b/opencode/plugins/shell-export-guard.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from "@opencode-ai/plugin";
+import { classifyShellExport } from "../scripts/shell-export-policy.mjs";
+
+const BLOCK_MESSAGE =
+  "Sensitive shell export blocked by policy; use an explicit non-secret value or a scoped secret-aware tool.";
+
+export const ShellExportGuardPlugin: Plugin = async () => ({
+  "tool.execute.before": async (input, output) => {
+    const tool = String(input?.tool ?? "").toLowerCase();
+    if (tool !== "bash" && tool !== "shell") return;
+
+    const args = output?.args;
+    if (!args || typeof args !== "object") return;
+
+    const command = (args as Record<string, unknown>).command;
+    if (typeof command !== "string") return;
+
+    const decision = classifyShellExport(command);
+    if (decision.blocked) {
+      throw new Error(`[shell-export-guard:${decision.rule}] ${BLOCK_MESSAGE}`);
+    }
+  },
+});

--- a/opencode/scripts/check-harness.mjs
+++ b/opencode/scripts/check-harness.mjs
@@ -2845,6 +2845,74 @@ function checkRetryPoliciesContract() {
   }
 }
 
+function checkShellExportGuardContract() {
+  const policyRel = "scripts/shell-export-policy.mjs";
+  const policyTestRel = "scripts/shell-export-policy.test.mjs";
+  const pluginRel = "plugins/shell-export-guard.ts";
+
+  for (const rel of [policyRel, policyTestRel, pluginRel]) {
+    if (!exists(rel)) fail(`${rel}: missing shell export guard surface`);
+  }
+
+  if (!exists(policyRel) || !exists(policyTestRel) || !exists(pluginRel)) return;
+
+  const policy = read(policyRel);
+  for (const token of [
+    "classifyShellExport",
+    "shell-export-environment-enumeration",
+    "shell-export-sensitive-name",
+    "shell-export-secret-source",
+    "-p",
+  ]) {
+    if (!policy.includes(token)) {
+      fail(`${policyRel}: missing shell export guard token ${token}`);
+    }
+  }
+
+  const plugin = read(pluginRel);
+  for (const token of [
+    "tool.execute.before",
+    "classifyShellExport",
+    "shell-export-guard",
+    "bash",
+    "shell",
+  ]) {
+    if (!plugin.includes(token)) {
+      fail(`${pluginRel}: missing shell export guard token ${token}`);
+    }
+  }
+  if (/\$\{?command\}?/.test(plugin)) {
+    fail(`${pluginRel}: shell export guard must not include the raw command in diagnostics`);
+  }
+
+  const policyTests = read(policyTestRel);
+  for (const token of [
+    "export",
+    "API_KEY",
+    "PATH",
+    "NODE_ENV",
+    "pi --export",
+    "quoted prose",
+  ]) {
+    if (!policyTests.includes(token)) {
+      fail(`${policyTestRel}: missing shell export policy scenario ${token}`);
+    }
+  }
+
+  const checksDocs = read("docs/ai/harness/checks.md");
+  const readmeDocs = read("docs/ai/harness/README.md");
+  for (const [rel, text] of [
+    ["docs/ai/harness/checks.md", checksDocs],
+    ["docs/ai/harness/README.md", readmeDocs],
+  ]) {
+    for (const token of ["shell-export", "defense in depth", "sandbox"]) {
+      if (!text.includes(token)) {
+        fail(`${rel}: missing shell export policy documentation token ${token}`);
+      }
+    }
+  }
+}
+
 checkConfig();
 checkAgentsIndex();
 checkFrontmatter();
@@ -2884,6 +2952,7 @@ checkOrchestratedReviewContract();
 checkHitlDurableContract();
 checkRoutingDeclarativoContract();
 checkRetryPoliciesContract();
+checkShellExportGuardContract();
 
 if (errors.length > 0) {
   console.error("Harness check failed:");

--- a/opencode/scripts/check-harness.test.mjs
+++ b/opencode/scripts/check-harness.test.mjs
@@ -94,6 +94,19 @@ test("orchestration contract file is required", () => {
   }
 });
 
+test("shell export guard surfaces are required", () => {
+  const cwd = makeFixture();
+  try {
+    fs.rmSync(path.join(cwd, "plugins/shell-export-guard.ts"));
+
+    const result = runHarness(cwd);
+    assert.notEqual(result.status, 0, "checker accepted a missing shell export guard");
+    assert.match(result.stderr, /plugins\/shell-export-guard\.ts: missing shell export guard surface/);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("orchestration contract file must be regular and non-symlink", () => {
   const cwd = makeFixture();
   const external = path.join(cwd, "external-contract.json");

--- a/opencode/scripts/shell-export-policy.d.mts
+++ b/opencode/scripts/shell-export-policy.d.mts
@@ -1,0 +1,4 @@
+export function classifyShellExport(command: unknown): {
+  blocked: boolean;
+  rule: string | null;
+};

--- a/opencode/scripts/shell-export-policy.mjs
+++ b/opencode/scripts/shell-export-policy.mjs
@@ -1,0 +1,272 @@
+const SAFE_DECISION = Object.freeze({ blocked: false, rule: null });
+
+export const SHELL_EXPORT_RULES = Object.freeze({
+  ENVIRONMENT_ENUMERATION: "shell-export-environment-enumeration",
+  SENSITIVE_NAME: "shell-export-sensitive-name",
+  SECRET_SOURCE: "shell-export-secret-source",
+});
+
+const SECRET_NAME_SUFFIXES = [
+  "API_KEY",
+  "TOKEN",
+  "SECRET",
+  "PASSWORD",
+  "CREDENTIALS",
+  "PRIVATE_KEY",
+  "COOKIE",
+  "AUTH_TOKEN",
+];
+
+const SECRET_READERS = new Set([
+  "aws",
+  "cat",
+  "curl",
+  "env",
+  "gcloud",
+  "op",
+  "pass",
+  "printenv",
+  "security",
+  "vault",
+  "wget",
+]);
+
+const VARIABLE_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function decision(rule) {
+  return { blocked: true, rule };
+}
+
+function isSensitiveName(name) {
+  const normalized = String(name).toUpperCase();
+  return SECRET_NAME_SUFFIXES.some(
+    (suffix) => normalized === suffix || normalized.endsWith(`_${suffix}`),
+  );
+}
+
+function splitShellCommands(command) {
+  const segments = [];
+  let start = 0;
+  let quote = null;
+  let escaped = false;
+  let comment = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+
+    if (comment) {
+      if (character === "\n") {
+        start = index + 1;
+        comment = false;
+      }
+      continue;
+    }
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+
+    if (character === "'" || character === '"' || character === "`") {
+      quote = character;
+      continue;
+    }
+
+    if (character === "#" && (index === 0 || /\s/.test(command[index - 1]))) {
+      segments.push(command.slice(start, index));
+      start = index + 1;
+      comment = true;
+      continue;
+    }
+
+    if (character === ";" || character === "|" || character === "&" || character === "\n") {
+      segments.push(command.slice(start, index));
+      if ((character === "|" || character === "&") && command[index + 1] === character) {
+        index += 1;
+      }
+      start = index + 1;
+    }
+  }
+
+  if (!comment) segments.push(command.slice(start));
+  return segments;
+}
+
+function tokenizeShellWords(text) {
+  const words = [];
+  let word = "";
+  let quote = null;
+  let escaped = false;
+
+  const push = () => {
+    if (word) words.push(word);
+    word = "";
+  };
+
+  for (const character of text) {
+    if (escaped) {
+      word += character;
+      escaped = false;
+      continue;
+    }
+
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        word += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"' || character === "`") {
+      quote = character;
+      word += character;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      push();
+      continue;
+    }
+
+    word += character;
+  }
+
+  if (escaped) word += "\\";
+  push();
+  return words;
+}
+
+function exportCommandFromSegment(segment) {
+  let remaining = segment.trim();
+
+  while (true) {
+    const keyword = remaining.match(/^(?:then|do|else|elif)\s+/);
+    if (!keyword) break;
+    remaining = remaining.slice(keyword[0].length).trimStart();
+  }
+
+  const match = remaining.match(/^export(?:\s+|$)/);
+  if (!match) return null;
+  return remaining.slice(match[0].length).trim();
+}
+
+function stripSingleQuotedText(value) {
+  let result = "";
+  let quote = null;
+
+  for (const character of value) {
+    if (quote === "'") {
+      if (character === "'") quote = null;
+      continue;
+    }
+    if (character === "'") {
+      quote = "'";
+      continue;
+    }
+    result += character;
+  }
+
+  return result;
+}
+
+function containsSensitiveEnvironmentReference(value) {
+  const unquoted = stripSingleQuotedText(value);
+  const references = unquoted.matchAll(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g);
+  for (const reference of references) {
+    if (isSensitiveName(reference[1])) return true;
+  }
+  return false;
+}
+
+function containsSecretReaderSubstitution(value) {
+  const unquoted = stripSingleQuotedText(value);
+  const substitutions = [
+    ...unquoted.matchAll(/\$\(([^()]*)\)/g),
+    ...unquoted.matchAll(/`([^`]*)`/g),
+  ];
+
+  for (const substitution of substitutions) {
+    const body = substitution[1];
+    const firstCommand = body.trim().match(/^([A-Za-z][A-Za-z0-9_-]*)\b/);
+    if (firstCommand && SECRET_READERS.has(firstCommand[1].toLowerCase())) return true;
+    if (/(?:;|\|\||&&|\|)\s*([A-Za-z][A-Za-z0-9_-]*)\b/.test(body)) {
+      const nestedCommands = body.matchAll(/(?:;|\|\||&&|\|)\s*([A-Za-z][A-Za-z0-9_-]*)\b/g);
+      for (const nested of nestedCommands) {
+        if (SECRET_READERS.has(nested[1].toLowerCase())) return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function classifyExportArguments(argumentsText) {
+  const words = tokenizeShellWords(argumentsText);
+  if (words.length === 0 || words.includes("-p")) {
+    return decision(SHELL_EXPORT_RULES.ENVIRONMENT_ENUMERATION);
+  }
+
+  const assignments = [];
+  const exportedNames = [];
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    const equalsIndex = word.indexOf("=");
+    if (equalsIndex === -1) {
+      if (VARIABLE_RE.test(word)) exportedNames.push(word);
+      continue;
+    }
+
+    const name = word.slice(0, equalsIndex);
+    if (VARIABLE_RE.test(name)) {
+      exportedNames.push(name);
+      assignments.push(word.slice(equalsIndex + 1));
+    }
+  }
+
+  if (exportedNames.some(isSensitiveName)) {
+    return decision(SHELL_EXPORT_RULES.SENSITIVE_NAME);
+  }
+
+  if (
+    assignments.some(
+      (value) =>
+        containsSensitiveEnvironmentReference(value) ||
+        containsSecretReaderSubstitution(value),
+    )
+  ) {
+    return decision(SHELL_EXPORT_RULES.SECRET_SOURCE);
+  }
+
+  return SAFE_DECISION;
+}
+
+export function classifyShellExport(command) {
+  if (typeof command !== "string" || command.length === 0) return SAFE_DECISION;
+
+  for (const segment of splitShellCommands(command)) {
+    const argumentsText = exportCommandFromSegment(segment);
+    if (argumentsText === null) continue;
+
+    const decisionForSegment = classifyExportArguments(argumentsText);
+    if (decisionForSegment.blocked) return decisionForSegment;
+  }
+
+  return SAFE_DECISION;
+}

--- a/opencode/scripts/shell-export-policy.test.mjs
+++ b/opencode/scripts/shell-export-policy.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyShellExport } from "./shell-export-policy.mjs";
+
+const sensitiveApiKeyName = ["OPENAI", "API_KEY"].join("_");
+
+const cases = [
+  {
+    name: "blocks bare export",
+    command: "export",
+    expected: { blocked: true, rule: "shell-export-environment-enumeration" },
+  },
+  {
+    name: "blocks export -p",
+    command: "export -p",
+    expected: { blocked: true, rule: "shell-export-environment-enumeration" },
+  },
+  {
+    name: "blocks a sensitive export name",
+    command: `export ${sensitiveApiKeyName}=literal`,
+    expected: { blocked: true, rule: "shell-export-sensitive-name" },
+  },
+  {
+    name: "blocks a secret source after a separator",
+    command: "printf x; export TOKEN=\"$(cat ~/.token)\"",
+    expected: { blocked: true, rule: "shell-export-sensitive-name" },
+  },
+  {
+    name: "blocks printenv of a sensitive variable",
+    command: `export VALUE="$(printenv ${sensitiveApiKeyName})"`,
+    expected: { blocked: true, rule: "shell-export-secret-source" },
+  },
+  {
+    name: "allows PATH setup",
+    command: 'export PATH="$PATH:/tool/bin"',
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "allows NODE_ENV setup",
+    command: "export NODE_ENV=test",
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "allows a non-secret derived value",
+    command: 'export BUILD_ID="$(git rev-parse HEAD)"',
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "ignores quoted prose",
+    command: 'echo "export TOKEN=..."',
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "ignores source-language export",
+    command: 'node -e "export const value = 1"',
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "ignores the Pi session export flag",
+    command: "pi --export session.html",
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "recognizes export after then",
+    command: "if true; then export API_TOKEN=literal; fi",
+    expected: { blocked: true, rule: "shell-export-sensitive-name" },
+  },
+  {
+    name: "ignores export text in a comment",
+    command: "echo ready # export API_TOKEN=literal",
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "ignores export text after a real assignment comment",
+    command: "export BUILD_CHANNEL=staging # export API_TOKEN=literal",
+    expected: { blocked: false, rule: null },
+  },
+  {
+    name: "does not block a non-sensitive exported variable",
+    command: "export BUILD_CHANNEL=staging",
+    expected: { blocked: false, rule: null },
+  },
+];
+
+for (const { name, command, expected } of cases) {
+  test(name, () => {
+    const decision = classifyShellExport(command);
+    assert.deepEqual(decision, expected);
+    assert.equal(Object.hasOwn(decision, "command"), false);
+  });
+}
+
+test("returns a safe decision for non-string input", () => {
+  assert.deepEqual(classifyShellExport(null), { blocked: false, rule: null });
+  assert.deepEqual(classifyShellExport({}), { blocked: false, rule: null });
+});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "check:supply-chain": "node scripts/check-supply-chain.mjs",
     "contract-check": "bash scripts/check.sh",
     "unit-and-script-tests": "node --test scripts/*.test.mjs opencode/scripts/*.test.mjs",
-    "typecheck": "npm --prefix opencode exec -- tsc --noEmit --jsx preserve --jsxImportSource @opentui/solid --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck opencode/plugins/token-tree-usage.tsx",
+    "typecheck": "npm --prefix opencode exec -- tsc --noEmit --jsx preserve --jsxImportSource @opentui/solid --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck opencode/plugins/token-tree-usage.tsx opencode/plugins/shell-export-guard.ts",
     "dependency-audit": "npm --prefix opencode audit --omit=dev --audit-level=low",
     "dependency-signature-audit": "npm --prefix opencode audit signatures",
     "installation-smoke": "bash scripts/install-smoke.sh",

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -47,8 +47,12 @@ opencode/.gitignore
 opencode/package.json
 opencode/package-lock.json
 opencode/plugins/token-tree-usage.tsx
+opencode/plugins/shell-export-guard.ts
 opencode/tools/open_design.ts
 opencode/scripts/check-harness.mjs
+opencode/scripts/shell-export-policy.mjs
+opencode/scripts/shell-export-policy.d.mts
+opencode/scripts/shell-export-policy.test.mjs
 opencode/commands/loop.md
 opencode/commands/plan.md
 opencode/commands/test.md


### PR DESCRIPTION
## Summary

- Add a high-signal shell export policy that blocks environment enumeration, sensitive export names, and secret-reading substitutions.
- Wire the policy into the local OpenCode shell hook without logging commands or values.
- Add public harness contract checks, focused tests, typecheck coverage, and English safety documentation.

## Why

A blanket export block would reject legitimate setup such as PATH and NODE_ENV. This guard keeps ordinary configuration allowed while adding defense in depth for high-signal secret propagation.

## Validation

- npm run check:release
- 1004 tests passed
- Typecheck passed, including the shell guard plugin
- Dependency audit: 0 vulnerabilities
- Dependency signatures: 128 verified packages and 29 verified attestations
- Installation smoke passed
- Package smoke passed

## Scope

This PR ports only the public OpenCode-safe subset. Private providers, MCP wiring, credentials, local paths, Pi adapter state, and AHE runtime evidence are intentionally excluded.
