### PR TITLE
fix: harden Open Design Docker entrypoint

### DIFF
--- a/docker/open-design/Dockerfile
+++ b/docker/open-design/Dockerfile
@@ -37,6 +37,8 @@ NODE
 RUN pnpm --filter @open-design/daemon build \
   && (pnpm build || pnpm -r build)
 
+COPY entrypoint.mjs /usr/local/bin/open-design-entrypoint.mjs
+
 ENV OD_HOST=0.0.0.0
 ENV OD_PORT=7456
 ENV OPENCODE_CONFIG_DIR=/home/opencode/.config/opencode
@@ -47,4 +49,4 @@ RUN mkdir -p /home/opencode/.config/opencode /home/opencode/.local/share/opencod
 USER opencode
 EXPOSE 7456
 
-CMD ["sh", "-lc", "node apps/daemon/dist/cli.js --port ${OD_PORT:-7456} --no-open"]
+ENTRYPOINT ["node", "/usr/local/bin/open-design-entrypoint.mjs"]

--- a/docker/open-design/entrypoint.mjs
+++ b/docker/open-design/entrypoint.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_PORT = "7456";
+const DAEMON_ENTRYPOINT = "apps/daemon/dist/cli.js";
+
+export function parsePort(rawPort) {
+  if (typeof rawPort !== "string" || !/^[0-9]+$/.test(rawPort)) {
+    throw new Error("OD_PORT must be a decimal TCP port between 1 and 65535");
+  }
+
+  const port = Number(rawPort);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error("OD_PORT must be a decimal TCP port between 1 and 65535");
+  }
+
+  return port;
+}
+
+export function daemonArguments(port) {
+  return [DAEMON_ENTRYPOINT, "--port", String(port), "--no-open"];
+}
+
+function main() {
+  let port;
+  try {
+    port = parsePort(process.env.OD_PORT ?? DEFAULT_PORT);
+  } catch (error) {
+    console.error(`Open Design startup failed: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const daemon = spawn(process.execPath, daemonArguments(port), { stdio: "inherit" });
+  const forwardSignal = (signal) => daemon.kill(signal);
+  const cleanup = () => {
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGTERM", onSigterm);
+  };
+  const onSigint = () => forwardSignal("SIGINT");
+  const onSigterm = () => forwardSignal("SIGTERM");
+
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  daemon.once("error", (error) => {
+    cleanup();
+    console.error(`Open Design daemon failed to start: ${error.message}`);
+    process.exitCode = 1;
+  });
+  daemon.once("exit", (code, signal) => {
+    cleanup();
+    process.exitCode = signal ? 1 : (code ?? 1);
+  });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/docs/docker-open-design.md
+++ b/docs/docker-open-design.md
@@ -45,6 +45,11 @@ The compose file mounts:
 
 Do not commit `data` or `opencode-auth`.
 
+`OD_PORT` must be a decimal TCP port from `1` to `65535`; it defaults to
+`7456`. The image validates this value before starting the daemon and passes it
+as a separate argument without a shell. Invalid values stop the container with
+a deterministic startup error.
+
 ## HTTP LAN and crypto.randomUUID
 
 Some browser APIs require a secure context. If Open Design frontend code calls `crypto.randomUUID` and your browser blocks it over HTTP LAN, prefer HTTPS. Only patch upstream frontend code as a local operational workaround.

--- a/scripts/open-design-entrypoint.test.mjs
+++ b/scripts/open-design-entrypoint.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { daemonArguments, parsePort } from "../docker/open-design/entrypoint.mjs";
+
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const ENTRYPOINT = path.join(ROOT, "docker/open-design/entrypoint.mjs");
+const DOCKERFILE = path.join(ROOT, "docker/open-design/Dockerfile");
+
+test("[OD001] parsePort accepts decimal ports in the valid range", () => {
+  for (const [raw, expected] of [["1", 1], ["7456", 7456], ["65535", 65535], ["07456", 7456]]) {
+    assert.equal(parsePort(raw), expected, raw);
+  }
+});
+
+for (const raw of ["", "0", "65536", "7456 ", " 7456", "+7456", "7456; touch marker", "7456\n--help"]) {
+  test(`[OD002] parsePort rejects unsafe value ${JSON.stringify(raw)}`, () => {
+    assert.throws(() => parsePort(raw), /OD_PORT.*1 and 65535/);
+  });
+}
+
+test("[OD003] daemon arguments keep the port as one argument", () => {
+  assert.deepEqual(daemonArguments(parsePort("7456")), [
+    "apps/daemon/dist/cli.js",
+    "--port",
+    "7456",
+    "--no-open",
+  ]);
+});
+
+test("[OD004] a shell metacharacter fails before any daemon can start", () => {
+  const marker = path.join(os.tmpdir(), `open-design-entrypoint-${process.pid}-marker`);
+  const result = spawnSync(process.execPath, [ENTRYPOINT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...process.env, OD_PORT: `7456; touch ${marker}` },
+  });
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /OD_PORT/);
+  assert.equal(fs.existsSync(marker), false);
+});
+
+test("[OD005] Docker uses an exec-form Node entrypoint without shell interpolation", () => {
+  const dockerfile = fs.readFileSync(DOCKERFILE, "utf8");
+  assert.match(dockerfile, /COPY entrypoint\.mjs \/usr\/local\/bin\/open-design-entrypoint\.mjs/);
+  assert.match(dockerfile, /ENTRYPOINT \["node", "\/usr\/local\/bin\/open-design-entrypoint\.mjs"\]/);
+  assert.doesNotMatch(dockerfile, /sh\s+-lc|\$\{OD_PORT/);
+});


### PR DESCRIPTION
## Summary

- Replace the shell-interpolated Docker `CMD` with an exec-form Node entrypoint.
- Validate `OD_PORT` as one decimal TCP port in the inclusive range `1..65535`.
- Pass the daemon port as a separate argument, forward termination signals, document the contract, and add regression tests.

## Investigation

The exact `OD_PORT=7456; ...` command-execution example from #6 is not reproduced by POSIX parameter expansion: shell metacharacters introduced by an unquoted parameter are not reparsed as shell syntax. The existing command still had a real unsafe boundary, however: whitespace could inject additional CLI arguments and arbitrary values were accepted without range validation. This PR removes the shell path entirely and rejects malformed values before spawning the daemon.

Fixes #6

## Validation

- `node --test scripts/open-design-entrypoint.test.mjs` — 12/12
- `npm run unit-and-script-tests` — 1,025/1,025
- `npm run contract-check` — passed
- `docker compose -f docker/open-design/docker-compose.yml config` — passed
- `docker build --check docker/open-design` — passed with no warnings