### PR TITLE
fix: bound Open Design HTTP and SSE transport

### DIFF
--- a/docs/open-design.md
+++ b/docs/open-design.md
@@ -23,3 +23,11 @@ Do not use project or file URLs.
 ## Security
 
 Do not expose Open Design directly to the Internet without authentication, VPN, Tailscale, WireGuard, or a secure reverse proxy.
+
+## Runtime budgets
+
+The Open Design client uses fixed safety budgets for remote calls: 5 seconds to
+receive response headers, 15 seconds of read-idle time, 120 seconds total per
+request, 1 MiB for JSON responses, 8 MiB for SSE responses, 2 MiB per stdout or
+stderr channel, and 10,000 SSE events. Oversized, stalled, or incomplete
+responses fail with a bounded diagnostic instead of being retained indefinitely.

--- a/opencode/tools/open-design-http.d.mts
+++ b/opencode/tools/open-design-http.d.mts
@@ -1,0 +1,45 @@
+export type OpenDesignHttpOptions = {
+  fetchImpl?: typeof fetch
+  connectTimeoutMs?: number
+  totalTimeoutMs?: number
+  idleTimeoutMs?: number
+  maxJsonBytes?: number
+  maxSseBytes?: number
+  maxOutputBytes?: number
+  maxEvents?: number
+  maxDiagnosticBytes?: number
+}
+
+export const OPEN_DESIGN_HTTP_LIMITS: Readonly<{
+  connectTimeoutMs: number
+  totalTimeoutMs: number
+  idleTimeoutMs: number
+  maxJsonBytes: number
+  maxSseBytes: number
+  maxOutputBytes: number
+  maxEvents: number
+  maxDiagnosticBytes: number
+}>
+
+export function requestJson(
+  base: string,
+  path: string,
+  init?: RequestInit,
+  options?: OpenDesignHttpOptions,
+): Promise<unknown>
+
+export function parseSseFrames(buffer: string): {
+  frames: Array<{ event: string; data: unknown }>
+  rest: string
+}
+
+export function streamOpenDesignChat(
+  base: string,
+  body: unknown,
+  options?: OpenDesignHttpOptions,
+): Promise<{
+  stdout: string
+  stderr: string
+  end: unknown
+  eventsCount: number
+}>

--- a/opencode/tools/open-design-http.mjs
+++ b/opencode/tools/open-design-http.mjs
@@ -1,0 +1,387 @@
+const DEFAULT_LIMITS = Object.freeze({
+  connectTimeoutMs: 5_000,
+  totalTimeoutMs: 120_000,
+  idleTimeoutMs: 15_000,
+  maxJsonBytes: 1_048_576,
+  maxSseBytes: 8_388_608,
+  maxOutputBytes: 2_097_152,
+  maxEvents: 10_000,
+  maxDiagnosticBytes: 4_000,
+});
+
+const LIMIT_BOUNDS = Object.freeze({
+  connectTimeoutMs: [100, 60_000],
+  totalTimeoutMs: [1_000, 300_000],
+  idleTimeoutMs: [100, 60_000],
+  maxJsonBytes: [1_024, 8_388_608],
+  maxSseBytes: [1_024, 16_777_216],
+  maxOutputBytes: [1_024, 8_388_608],
+  maxEvents: [1, 100_000],
+  maxDiagnosticBytes: [256, 16_000],
+});
+
+const encoder = new TextEncoder();
+
+export const OPEN_DESIGN_HTTP_LIMITS = DEFAULT_LIMITS;
+
+function resolveLimits(overrides = {}) {
+  return Object.fromEntries(
+    Object.entries(DEFAULT_LIMITS).map(([name, fallback]) => {
+      const [minimum, maximum] = LIMIT_BOUNDS[name];
+      const value = Number(overrides[name]);
+      return [
+        name,
+        Number.isFinite(value)
+          ? Math.min(maximum, Math.max(minimum, Math.floor(value)))
+          : fallback,
+      ];
+    }),
+  );
+}
+
+function stringify(value) {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function preview(value, maxBytes) {
+  const text = stringify(value);
+  if (encoder.encode(text).byteLength <= maxBytes) return text;
+
+  let result = text.slice(0, Math.max(0, maxBytes - 3));
+  while (result && encoder.encode(`${result}...`).byteLength > maxBytes) {
+    result = result.slice(0, -1);
+  }
+  return `${result}...`;
+}
+
+function tailPreview(value, maxBytes) {
+  const text = stringify(value);
+  if (encoder.encode(text).byteLength <= maxBytes) return text;
+
+  let result = text.slice(-Math.max(0, maxBytes - 3));
+  while (result && encoder.encode(`...${result}`).byteLength > maxBytes) {
+    result = result.slice(1);
+  }
+  return `...${result}`;
+}
+
+function timeoutError(message) {
+  return new Error(`Open Design request ${message}`);
+}
+
+function createBudget(limits) {
+  const controller = new AbortController();
+  let failure = null;
+  let connectTimer;
+  let totalTimer;
+  let rejectConnectTimeout;
+  let rejectTotalTimeout;
+
+  const abort = (error) => {
+    if (failure) return failure;
+    failure = error instanceof Error ? error : new Error(String(error));
+    controller.abort(failure);
+    return failure;
+  };
+
+  const connectTimeout = new Promise((_, reject) => {
+    rejectConnectTimeout = reject;
+    connectTimer = setTimeout(() => {
+      const error = abort(timeoutError("timed out while connecting"));
+      rejectConnectTimeout(error);
+    }, limits.connectTimeoutMs);
+  });
+  const totalTimeout = new Promise((_, reject) => {
+    rejectTotalTimeout = reject;
+    totalTimer = setTimeout(() => {
+      const error = abort(timeoutError("timed out"));
+      rejectTotalTimeout(error);
+    }, limits.totalTimeoutMs);
+  });
+  void totalTimeout.catch(() => {});
+
+  return {
+    signal: controller.signal,
+    connectTimeout,
+    totalTimeout,
+    markHeadersReceived() {
+      clearTimeout(connectTimer);
+    },
+    abort,
+    errorOr(error) {
+      return failure || error;
+    },
+    dispose() {
+      clearTimeout(connectTimer);
+      clearTimeout(totalTimer);
+    },
+  };
+}
+
+async function fetchWithBudget(url, init, options) {
+  const limits = resolveLimits(options);
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Open Design requires a fetch implementation");
+  }
+
+  const budget = createBudget(limits);
+  try {
+    const response = await Promise.race([
+      Promise.resolve().then(() => fetchImpl(url, { ...init, signal: budget.signal })),
+      budget.connectTimeout,
+      budget.totalTimeout,
+    ]);
+    budget.markHeadersReceived();
+    return { response, budget, limits };
+  } catch (error) {
+    const failure = budget.errorOr(error);
+    budget.dispose();
+    throw failure;
+  }
+}
+
+async function readWithIdleTimeout(reader, budget, idleTimeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          reject(budget.abort(timeoutError("timed out while reading")));
+        }, idleTimeoutMs);
+      }),
+      budget.totalTimeout,
+    ]);
+  } catch (error) {
+    throw budget.errorOr(error);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function cancelResponseBody(response) {
+  try {
+    await response.body?.cancel?.();
+  } catch {
+    // The response is already being aborted; cancellation is best-effort.
+  }
+}
+
+async function readBoundedText(response, budget, limits, label, maxBytes = limits.maxJsonBytes) {
+  const contentLength = Number(response.headers?.get?.("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    const error = new Error(`${label} response exceeds ${maxBytes} bytes`);
+    budget.abort(error);
+    await cancelResponseBody(response);
+    throw error;
+  }
+
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const parts = [];
+  let bytes = 0;
+
+  try {
+    while (true) {
+      const { value, done } = await readWithIdleTimeout(reader, budget, limits.idleTimeoutMs);
+      if (done) break;
+
+      bytes += value.byteLength;
+      if (bytes > maxBytes) {
+        const error = new Error(`${label} response exceeds ${maxBytes} bytes`);
+        budget.abort(error);
+        throw error;
+      }
+      parts.push(decoder.decode(value, { stream: true }));
+    }
+    parts.push(decoder.decode());
+    return parts.join("");
+  } catch (error) {
+    budget.abort(error);
+    await reader.cancel().catch(() => {});
+    throw budget.errorOr(error);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export async function requestJson(base, path, init = {}, options = {}) {
+  const { response, budget, limits } = await fetchWithBudget(`${base}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers || {}),
+    },
+  }, options);
+
+  try {
+    const text = await readBoundedText(response, budget, limits, `Open Design ${path}`);
+    let body = text;
+
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      body = text;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Open Design ${path} failed (${response.status}): ${preview(body, limits.maxDiagnosticBytes)}`,
+      );
+    }
+
+    return body;
+  } finally {
+    budget.dispose();
+  }
+}
+
+function eventDelimiter(input) {
+  const candidates = [
+    [input.indexOf("\r\n\r\n"), 4],
+    [input.indexOf("\n\n"), 2],
+    [input.indexOf("\r\r"), 2],
+  ].filter(([index]) => index !== -1);
+
+  return candidates.sort(([left], [right]) => left - right)[0] ?? null;
+}
+
+export function parseSseFrames(buffer) {
+  const frames = [];
+  let rest = buffer;
+
+  while (true) {
+    const delimiter = eventDelimiter(rest);
+    if (!delimiter) break;
+
+    const [index, length] = delimiter;
+    const raw = rest.slice(0, index);
+    rest = rest.slice(index + length);
+
+    let event = "message";
+    const dataLines = [];
+    for (const line of raw.split(/\r\n|\n|\r/)) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+    }
+
+    const dataText = dataLines.join("\n");
+    let data = dataText;
+    try {
+      data = dataText ? JSON.parse(dataText) : null;
+    } catch {
+      // Keep non-JSON SSE payloads as text.
+    }
+    frames.push({ event, data });
+  }
+
+  return { frames, rest };
+}
+
+function appendOutput(parts, bytes, value, limits) {
+  const text = String(value ?? "");
+  const nextBytes = bytes + encoder.encode(text).byteLength;
+  if (nextBytes > limits.maxOutputBytes) {
+    throw new Error(`Open Design stdout/stderr output exceeds ${limits.maxOutputBytes} bytes`);
+  }
+  parts.push(text);
+  return nextBytes;
+}
+
+export async function streamOpenDesignChat(base, body, options = {}) {
+  const { response, budget, limits } = await fetchWithBudget(`${base}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }, options);
+
+  try {
+    if (!response.ok || !response.body) {
+      const text = await readBoundedText(response, budget, limits, "Open Design chat");
+      throw new Error(`Open Design chat failed (${response.status}): ${preview(text, limits.maxDiagnosticBytes)}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const stdoutParts = [];
+    const stderrParts = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let buffer = "";
+    let streamBytes = 0;
+    let end = null;
+    let eventsCount = 0;
+
+    try {
+      while (true) {
+        const { value, done } = await readWithIdleTimeout(reader, budget, limits.idleTimeoutMs);
+        if (done) {
+          buffer += decoder.decode();
+          break;
+        }
+
+        streamBytes += value.byteLength;
+        if (streamBytes > limits.maxSseBytes) {
+          throw new Error(`Open Design SSE response exceeds ${limits.maxSseBytes} bytes`);
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+        const parsed = parseSseFrames(buffer);
+        buffer = parsed.rest;
+
+        for (const frame of parsed.frames) {
+          eventsCount += 1;
+          if (eventsCount > limits.maxEvents) {
+            throw new Error(`Open Design SSE event count exceeds ${limits.maxEvents}`);
+          }
+
+          if (frame.event === "stdout") {
+            stdoutBytes = appendOutput(stdoutParts, stdoutBytes, frame.data?.chunk, limits);
+          }
+          if (frame.event === "stderr") {
+            stderrBytes = appendOutput(stderrParts, stderrBytes, frame.data?.chunk, limits);
+          }
+          if (frame.event === "agent") {
+            if (typeof frame.data?.delta === "string") {
+              stdoutBytes = appendOutput(stdoutParts, stdoutBytes, frame.data.delta, limits);
+            }
+            if (typeof frame.data?.text === "string") {
+              stdoutBytes = appendOutput(stdoutParts, stdoutBytes, frame.data.text, limits);
+            }
+          }
+          if (frame.event === "end") end = frame.data;
+          if (frame.event === "error") {
+            throw new Error(
+              `Open Design agent error: ${preview(frame.data?.message ?? frame.data, limits.maxDiagnosticBytes)}`,
+            );
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        throw new Error("Open Design SSE stream ended with an incomplete event");
+      }
+      if (end && typeof end.code === "number" && end.code !== 0) {
+        throw new Error(`Open Design agent exited with code ${end.code}\n${tailPreview(stderrParts.join(""), 1_000)}`);
+      }
+
+      return { stdout: stdoutParts.join(""), stderr: stderrParts.join(""), end, eventsCount };
+    } catch (error) {
+      budget.abort(error);
+      await reader.cancel().catch(() => {});
+      throw budget.errorOr(error);
+    } finally {
+      reader.releaseLock();
+    }
+  } finally {
+    budget.dispose();
+  }
+}

--- a/opencode/tools/open_design.ts
+++ b/opencode/tools/open_design.ts
@@ -1,4 +1,5 @@
 import { tool } from "@opencode-ai/plugin"
+import { requestJson, streamOpenDesignChat } from "./open-design-http.mjs"
 
 type RuntimeGlobals = {
   process?: { env?: Record<string, string | undefined> }
@@ -44,31 +45,6 @@ function baseUrl(input?: string) {
   }
 
   return url
-}
-
-async function requestJson(base: string, path: string, init: RequestInit = {}) {
-  const res = await fetch(`${base}${path}`, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(init.headers || {}),
-    },
-  })
-
-  const text = await res.text()
-  let body: unknown = text
-
-  try {
-    body = text ? JSON.parse(text) : null
-  } catch {
-    body = text
-  }
-
-  if (!res.ok) {
-    throw new Error(`Open Design ${path} failed (${res.status}): ${JSON.stringify(body, null, 2)}`)
-  }
-
-  return body
 }
 
 function safeSlug(input: string) {
@@ -124,83 +100,6 @@ function composeSystemPrompt(input: {
       ? `## Active design system: ${input.designSystemId}\n\n${input.designSystemBody}`
       : "## Active design system\n\nNo explicit design system selected. Use a restrained, professional default.",
   ].join("\n")
-}
-
-function parseSseFrames(buffer: string) {
-  const frames: Array<{ event: string; data: any }> = []
-  let rest = buffer
-
-  while (true) {
-    const idx = rest.indexOf("\n\n")
-    if (idx === -1) break
-    const raw = rest.slice(0, idx)
-    rest = rest.slice(idx + 2)
-
-    let event = "message"
-    let data = ""
-    for (const line of raw.split("\n")) {
-      if (line.startsWith("event: ")) event = line.slice(7).trim()
-      if (line.startsWith("data: ")) data += line.slice(6)
-    }
-
-    try {
-      frames.push({ event, data: JSON.parse(data) })
-    } catch {
-      frames.push({ event, data })
-    }
-  }
-
-  return { frames, rest }
-}
-
-async function streamOpenDesignChat(base: string, body: unknown) {
-  const res = await fetch(`${base}/api/chat`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  })
-
-  if (!res.ok || !res.body) {
-    const text = await res.text().catch(() => "")
-    throw new Error(`Open Design chat failed (${res.status}): ${text}`)
-  }
-
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ""
-  let stdout = ""
-  let stderr = ""
-  let end: any = null
-  let eventsCount = 0
-
-  while (true) {
-    const { value, done } = await reader.read()
-    if (done) break
-
-    buffer += decoder.decode(value, { stream: true })
-    const parsed = parseSseFrames(buffer)
-    buffer = parsed.rest
-
-    for (const frame of parsed.frames) {
-      eventsCount += 1
-      if (frame.event === "stdout") stdout += String(frame.data?.chunk ?? "")
-      if (frame.event === "stderr") stderr += String(frame.data?.chunk ?? "")
-      if (frame.event === "agent") {
-        if (typeof frame.data?.delta === "string") stdout += frame.data.delta
-        if (typeof frame.data?.text === "string") stdout += frame.data.text
-      }
-      if (frame.event === "end") end = frame.data
-      if (frame.event === "error") {
-        throw new Error(`Open Design agent error: ${String(frame.data?.message ?? JSON.stringify(frame.data))}`)
-      }
-    }
-  }
-
-  if (end && typeof end.code === "number" && end.code !== 0) {
-    throw new Error(`Open Design agent exited with code ${end.code}\n${stderr.slice(-1000)}`)
-  }
-
-  return { stdout, stderr, end, eventsCount }
 }
 
 export const health = tool({

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "check:supply-chain": "node scripts/check-supply-chain.mjs",
     "contract-check": "bash scripts/check.sh",
     "unit-and-script-tests": "node --test scripts/*.test.mjs opencode/scripts/*.test.mjs",
-    "typecheck": "npm --prefix opencode exec -- tsc --noEmit --jsx preserve --jsxImportSource @opentui/solid --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck opencode/plugins/token-tree-usage.tsx opencode/plugins/shell-export-guard.ts",
+    "typecheck": "npm --prefix opencode exec -- tsc --noEmit --jsx preserve --jsxImportSource @opentui/solid --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck opencode/plugins/token-tree-usage.tsx opencode/plugins/shell-export-guard.ts opencode/tools/open_design.ts",
     "dependency-audit": "npm --prefix opencode audit --omit=dev --audit-level=low",
     "dependency-signature-audit": "npm --prefix opencode audit signatures",
     "installation-smoke": "bash scripts/install-smoke.sh",

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -49,6 +49,8 @@ opencode/package-lock.json
 opencode/plugins/token-tree-usage.tsx
 opencode/plugins/shell-export-guard.ts
 opencode/tools/open_design.ts
+opencode/tools/open-design-http.mjs
+opencode/tools/open-design-http.d.mts
 opencode/scripts/check-harness.mjs
 opencode/scripts/shell-export-policy.mjs
 opencode/scripts/shell-export-policy.d.mts

--- a/scripts/open-design-http.test.mjs
+++ b/scripts/open-design-http.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const openDesign = await import("../opencode/tools/open-design-http.mjs");
+const { requestJson, streamOpenDesignChat } = openDesign;
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function trackedStream(chunks, state = {}) {
+  let index = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(new TextEncoder().encode(chunks[index++]));
+      } else {
+        controller.close();
+      }
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  });
+}
+
+function chatResponse(chunks, state = {}) {
+  return new Response(trackedStream(chunks, state), { status: 200 });
+}
+
+function options(fetchImpl, overrides = {}) {
+  return { fetchImpl, ...overrides };
+}
+
+test("Open Design exposes bounded HTTP and SSE transport helpers", () => {
+  assert.equal(typeof requestJson, "function");
+  assert.equal(typeof streamOpenDesignChat, "function");
+});
+
+test("the Open Design tool delegates network reads to the bounded transport", () => {
+  const source = fs.readFileSync(path.join(ROOT, "opencode/tools/open_design.ts"), "utf8");
+  assert.match(source, /from ["']\.\/open-design-http\.mjs["']/);
+  assert.doesNotMatch(source, /await fetch\(/);
+  assert.doesNotMatch(source, /await res\.text\(/);
+});
+
+test("requestJson aborts a request that stalls before response headers", async () => {
+  await assert.rejects(
+    requestJson("http://open-design.test", "/api/health", {}, options(() => new Promise(() => {}), {
+      connectTimeoutMs: 100,
+    })),
+    /timed out while connecting/,
+  );
+});
+
+test("requestJson cancels an oversized response before parsing it", async () => {
+  const state = {};
+  const response = new Response(trackedStream(["x".repeat(2_048), "x"], state), {
+    status: 200,
+    headers: { "content-length": "2048" },
+  });
+
+  await assert.rejects(
+    requestJson("http://open-design.test", "/api/health", {}, options(async () => response, {
+      maxJsonBytes: 1_024,
+    })),
+    /response exceeds 1024 bytes/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("streamOpenDesignChat parses partial CRLF-framed SSE events", async () => {
+  const chunks = [
+    "event: stdout\r\ndata: {\"chunk\":\"hel",
+    "lo\"}\r\n\r\nevent: agent\r\ndata: {\"delta\":\" world\"}\r\n\r\nevent: end\r\ndata: {\"code\":0}\r\n\r\n",
+  ];
+
+  const result = await streamOpenDesignChat(
+    "http://open-design.test",
+    { prompt: "test" },
+    options(async () => chatResponse(chunks), { maxEvents: 10 }),
+  );
+
+  assert.equal(result.stdout, "hello world");
+  assert.equal(result.stderr, "");
+  assert.equal(result.eventsCount, 3);
+  assert.deepEqual(result.end, { code: 0 });
+});
+
+test("streamOpenDesignChat keeps the tail of bounded stderr on non-zero exit", async () => {
+  const stderr = `head-marker ${"x".repeat(1_500)} tail-marker`;
+  const frames = [
+    `event: stderr\ndata: ${JSON.stringify({ chunk: stderr })}\n\n`,
+    "event: end\ndata: {\"code\":2}\n\n",
+  ];
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => chatResponse(frames)),
+    ),
+    /tail-marker/,
+  );
+});
+
+test("streamOpenDesignChat cancels the reader when output exceeds its cap", async () => {
+  const state = {};
+  const frame = `event: stdout\ndata: ${JSON.stringify({ chunk: "x".repeat(1_500) })}\n\n`;
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => chatResponse([frame, frame], state), { maxOutputBytes: 1_024 }),
+    ),
+    /stdout\/stderr output exceeds 1024 bytes/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("streamOpenDesignChat rejects an oversized SSE body and cancels the reader", async () => {
+  const state = {};
+  const oversizedComment = `: ${"x".repeat(1_500)}\n\n`;
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => chatResponse([oversizedComment, oversizedComment], state), {
+        maxSseBytes: 1_024,
+      }),
+    ),
+    /SSE response exceeds 1024 bytes/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("streamOpenDesignChat rejects an excessive event count and cancels the reader", async () => {
+  const state = {};
+  const frame = "event: stdout\ndata: {\"chunk\":\"x\"}\n\n";
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => chatResponse([frame + frame + frame, frame], state), { maxEvents: 2 }),
+    ),
+    /SSE event count exceeds 2/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("streamOpenDesignChat cancels an idle stream deterministically", async () => {
+  const state = {};
+  const response = new Response(new ReadableStream({
+    pull() {
+      return new Promise(() => {});
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  }), { status: 200 });
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => response, { idleTimeoutMs: 100, totalTimeoutMs: 2_000 }),
+    ),
+    /timed out while reading/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("streamOpenDesignChat enforces the total request timeout", async () => {
+  const state = {};
+  const response = new Response(new ReadableStream({
+    pull() {
+      return new Promise(() => {});
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  }), { status: 200 });
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => response, { idleTimeoutMs: 2_000, totalTimeoutMs: 1_000 }),
+    ),
+    /Open Design request timed out$/,
+  );
+  assert.equal(state.cancelled, true);
+});
+
+test("streamOpenDesignChat cancels the reader on an agent error event", async () => {
+  const state = {};
+  const errorFrame = "event: error\ndata: {\"message\":\"upstream failed\"}\n\n";
+
+  await assert.rejects(
+    streamOpenDesignChat(
+      "http://open-design.test",
+      { prompt: "test" },
+      options(async () => chatResponse([errorFrame, "event: stdout\ndata: {}\n\n"], state)),
+    ),
+    /Open Design agent error: upstream failed/,
+  );
+  assert.equal(state.cancelled, true);
+});


### PR DESCRIPTION
## Summary

- Move Open Design HTTP/SSE reads into a bounded transport shared by the tool.
- Add connect/header, total, and idle-read timeouts with AbortController and explicit fetch/header race.
- Bound JSON/SSE body bytes, stdout/stderr bytes, event count, diagnostics; handle partial/CRLF SSE frames; cancel on limit/error paths.
- Add `.d.mts`, docs, standard typecheck inclusion, and deterministic tests.

## Investigation

Issue #8 was reproducible from the code: `requestJson` used unbounded `res.text()`, and `streamOpenDesignChat` accumulated complete stream/output until server close. The transport now fails deterministically on stalled, oversized, or incomplete responses and keeps bounded previews.

Fixes #8

## Validation

- `node --test scripts/open-design-http.test.mjs` — 12/12
- `npm run unit-and-script-tests` — 1,025/1,025
- `npm run contract-check` — passed
- `npm run typecheck` — passed
- targeted TypeScript check for `open_design.ts` — passed
- direct module import — passed
- independent reviewer — no critical, important, or minor findings